### PR TITLE
Add support in Names and Role Provisioning Services for lti11_legacy_user_id and Fix handling of string[] claim types

### DIFF
--- a/src/LtiAdvantage/LtiAdvantage.xml
+++ b/src/LtiAdvantage/LtiAdvantage.xml
@@ -3331,6 +3331,13 @@
             Corresponds to the "sub" claim.
             </summary>
         </member>
+        <member name="P:LtiAdvantage.NamesRoleProvisioningService.Member.Lti11LegacyUserId">
+            <summary>
+            If the user id is changing with the migration to LTI 1.3, a platform should include the lti11_legacy_user_id
+            as an additional member attribute. It should contain the userId value from LTI 1.1 Names and Roles Provisioning
+            Service 1.0 for that same user.
+            </summary>
+        </member>
         <member name="T:LtiAdvantage.NamesRoleProvisioningService.MembershipContainer">
             <summary>
             Represents the results returned by the Membership service.

--- a/src/LtiAdvantage/NamesRoleProvisioningService/Member.cs
+++ b/src/LtiAdvantage/NamesRoleProvisioningService/Member.cs
@@ -92,5 +92,13 @@ namespace LtiAdvantage.NamesRoleProvisioningService
         /// </summary>
         [JsonProperty("user_id")]
         public string UserId { get; set; }
+
+        /// <summary>
+        /// If the user id is changing with the migration to LTI 1.3, a platform should include the lti11_legacy_user_id
+        /// as an additional member attribute. It should contain the userId value from LTI 1.1 Names and Roles Provisioning
+        /// Service 1.0 for that same user.
+        /// </summary>
+        [JsonProperty("lti11_legacy_user_id")]
+        public string Lti11LegacyUserId { get; set; }
     }
 }

--- a/src/LtiAdvantage/Utilities/JwtExtensions.cs
+++ b/src/LtiAdvantage/Utilities/JwtExtensions.cs
@@ -45,7 +45,7 @@ namespace LtiAdvantage.Utilities
                     : JsonConvert.DeserializeObject<T>(value.ToString());
             }
 
-            return default(T);
+            return default;
         }
 
         private static T GetClaimValues<T>(this JwtPayload payload, string type)
@@ -54,8 +54,11 @@ namespace LtiAdvantage.Utilities
                 .Where(c => c.Type == type)
                 .Select(c => c.Value).ToArray();
 
+            if (0 == values.Length)
+                return default;
+
             var elementType = typeof(T).GetElementType();
-            if (elementType != null && elementType.IsClass)
+            if (elementType != null && elementType.IsClass && !elementType.IsEquivalentTo(typeof(string)))
             {
                 return JsonConvert.DeserializeObject<T>("[" + string.Join(",", values) + "]");
             }

--- a/src/LtiAdvantage/Utilities/JwtExtensions.cs
+++ b/src/LtiAdvantage/Utilities/JwtExtensions.cs
@@ -45,7 +45,7 @@ namespace LtiAdvantage.Utilities
                     : JsonConvert.DeserializeObject<T>(value.ToString());
             }
 
-            return default;
+            return default(T);
         }
 
         private static T GetClaimValues<T>(this JwtPayload payload, string type)
@@ -55,7 +55,7 @@ namespace LtiAdvantage.Utilities
                 .Select(c => c.Value).ToArray();
 
             if (0 == values.Length)
-                return default;
+                return default(T);
 
             var elementType = typeof(T).GetElementType();
             if (elementType != null && elementType.IsClass && !elementType.IsEquivalentTo(typeof(string)))


### PR DESCRIPTION
- This is also provided in the JWT token parser for launches, but the IMS migration guidance technically only provides for this value from NRPS. In any case, it's important to have support for this value from NRPS.