### PR TITLE
First Attempt at moving Build to Github Actions

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -8,8 +8,11 @@ on:
 
 jobs:
   build:
-
-    runs-on: windows-latest
+    strategy:
+      matrix:
+        platform: [ windows-latest, ubuntu-latest ]
+    
+    runs-on: ${{ matrix.platform }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -16,10 +16,8 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.2
-    - name: Install dependencies
-      run: dotnet restore
+        dotnet-version: 2.2.402
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Release
     - name: Test
       run: dotnet test --configuration Release --results-directory artifacts --no-build

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -1,0 +1,25 @@
+name: .NET Core
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 2.2
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+    - name: Test
+      run: dotnet test --configuration Release --results-directory artifacts --no-build


### PR DESCRIPTION
## Background
The respository currently builds on travis for each commit. Since, we now have github actions available with us, moving to those might also help us with future benefits such as managing releases and publishing nuget packages from this repository.

## Aim
This change aims to take a shot at migrating our continuous build and test system to github actions.

## Testing
I have tested the changes in my local fork of the repository against push to `master`, pull_request to `master` and push to other branch to make sure triggers are working correctly and builds are passing across both ubuntu and windows. Please see https://github.com/adbindal/LtiAdvantage/actions for reference.

> I'd be willing to understand if deprecating travis-ci is something that I can do or what is the best way forward to mark this system as default.