### PR TITLE
Update MembershipContainerType as per lti-nrps Spec

### DIFF
--- a/src/LtiAdvantage/Constants.cs
+++ b/src/LtiAdvantage/Constants.cs
@@ -248,7 +248,7 @@
             /// <summary>
             /// https://www.imsglobal.org/spec/lti-nrps/v2p0#membership-container-media-type
             /// </summary>
-            public const string MembershipContainer = "application/vnd.ims.lis.v2.membershipcontainer+json";
+            public const string MembershipContainer = "application/vnd.ims.lti-nrps.v2.membershipcontainer+json";
 
             /// <summary>
             /// https://www.imsglobal.org/spec/lti-ags/v2p0/#media-types-and-schemas


### PR DESCRIPTION
The `MembershipContainerType` points to `lis` container instead of `lti-nrps` container causing unnecessary failures when parsing membership api response from the LtiAdvantage Platforms. Fixing to point to the correct one present at https://www.imsglobal.org/spec/lti-nrps/v2p0#membership-container-media-type