### PR TITLE
First Attempt at setting up a NuGet publish pipeline

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -8,6 +8,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Fetch tags
+      run: |
+        git fetch origin +refs/tags/*:refs/tags/*
+        git fetch --prune --unshallow
     - name: Build Reason
       run: "echo ref: ${{github.ref}} event: ${{github.event_name}}"
     - name: Build Version
@@ -15,7 +19,6 @@ jobs:
       uses: thefringeninja/action-minver@2.0.0-preview1
       with:
         tag-prefix: v
-        verbosity: trace
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -14,11 +14,6 @@ jobs:
         git fetch --prune --unshallow
     - name: Build Reason
       run: "echo ref: ${{github.ref}} event: ${{github.event_name}}"
-    - name: Build Version
-      id: version
-      uses: thefringeninja/action-minver@2.0.0-preview1
-      with:
-        tag-prefix: v
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -1,21 +1,21 @@
 name: .NET Core
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        platform: [ windows-latest, ubuntu-latest ]
-    
-    runs-on: ${{ matrix.platform }}
+  ci:    
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2
+    - name: Build Reason
+      run: "echo ref: ${{github.ref}} event: ${{github.event_name}}"
+    - name: Build Version
+      id: version
+      uses: thefringeninja/action-minver@2.0.0-preview1
+      with:
+        tag-prefix: v
+        verbosity: trace
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -25,7 +25,7 @@ jobs:
         dotnet-version: 2.2.402
         source-url: https://nuget.pkg.github.com/LtiLibrary/index.json
       env:
-        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        NUGET_AUTH_TOKEN: ${{secrets.NUGET_TOKEN}}
     - name: Build
       run: dotnet build --configuration Release
     - name: Test

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -25,7 +25,7 @@ jobs:
         dotnet-version: 2.2.402
         source-url: https://nuget.pkg.github.com/LtiLibrary/index.json
       env:
-        NUGET_AUTH_TOKEN: ${{secrets.NUGET_TOKEN}}
+        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     - name: Build
       run: dotnet build --configuration Release
     - name: Test

--- a/src/LtiAdvantage.IdentityModel/LtiAdvantage.IdentityModel.csproj
+++ b/src/LtiAdvantage.IdentityModel/LtiAdvantage.IdentityModel.csproj
@@ -1,7 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>.NET Core library with IMS LTIAdvantage support for Tool Consumer and Tool Provider applications.</Description>
+    <AssemblyTitle>LtiAdvantage.IdentityModel</AssemblyTitle>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>LtiAdvantage.IdentityModel</AssemblyName>
+    <PackageId>LtiAdvantage.IdentityModel</PackageId>
+    <PackageTags>IMS;LTI;LTIAdvantage;.NET Core</PackageTags>
+    <PackageProjectUrl>https://github.com/LtiLibrary/LtiAdvantage</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/LtiLibrary/LtiAdvantage/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/LtiLibrary/LtiAdvantage</RepositoryUrl>
     <MinVerTagPrefix>v</MinVerTagPrefix>

--- a/src/LtiAdvantage.IdentityServer4/LtiAdvantage.IdentityServer4.csproj
+++ b/src/LtiAdvantage.IdentityServer4/LtiAdvantage.IdentityServer4.csproj
@@ -1,7 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>.NET Core library with IMS LTIAdvantage support for Tool Consumer and Tool Provider applications.</Description>
+    <AssemblyTitle>LtiAdvantage.IdentityServer4</AssemblyTitle>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>LtiAdvantage.IdentityServer4</AssemblyName>
+    <PackageId>LtiAdvantage.IdentityServer4</PackageId>
+    <PackageTags>IMS;LTI;LTIAdvantage;.NET Core</PackageTags>
+    <PackageProjectUrl>https://github.com/LtiLibrary/LtiAdvantage</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/LtiLibrary/LtiAdvantage/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/LtiLibrary/LtiAdvantage</RepositoryUrl>
     <MinVerTagPrefix>v</MinVerTagPrefix>

--- a/src/LtiAdvantage/LtiAdvantage.csproj
+++ b/src/LtiAdvantage/LtiAdvantage.csproj
@@ -1,7 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>.NET Core library with IMS LTIAdvantage support for Tool Consumer and Tool Provider applications.</Description>
+    <AssemblyTitle>LtiAdvantage</AssemblyTitle>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>LtiAdvantage</AssemblyName>
+    <PackageId>LtiAdvantage</PackageId>
+    <PackageTags>IMS;LTI;LTIAdvantage;.NET Core</PackageTags>
+    <PackageProjectUrl>https://github.com/LtiLibrary/LtiAdvantage</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/LtiLibrary/LtiAdvantage/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/LtiLibrary/LtiAdvantage</RepositoryUrl>
     <MinVerTagPrefix>v</MinVerTagPrefix>

--- a/test/LtiAdvantage.IntegrationTests/LtiAdvantage.IntegrationTests.csproj
+++ b/test/LtiAdvantage.IntegrationTests/LtiAdvantage.IntegrationTests.csproj
@@ -9,6 +9,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
+    <PackageReference Include="MinVer" Version="2.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/test/LtiAdvantage.UnitTests/LtiAdvantage.UnitTests.csproj
+++ b/test/LtiAdvantage.UnitTests/LtiAdvantage.UnitTests.csproj
@@ -38,6 +38,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MinVer" Version="2.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

* **Switch to building only Windows**: duplicate publishing might cause issues. If this works, we can try solving that problem separately.
* **Move the build & publish to trigger to on every push**: restricting to master would not re-trigger the workflow upon creation of tags and releases.
* **Add metadata to CsProj Files**: ^^I believe this is used for NuGet publishing, especially the `Assembly<Name/Title>`.
* **Add `@action/minver` to the workflow**: allows proper versioning of the `nupkg` files (see [workflow#step:10.9](https://github.com/adbindal/LtiAdvantage/runs/972621478?check_suite_focus=true#step:10:9))

> _^^_**Note:** I might stand corrected on this one. But it is better to add this info anyways.