### PR TITLE
Lti11 migration Claims

### DIFF
--- a/src/LtiAdvantage/Constants.cs
+++ b/src/LtiAdvantage/Constants.cs
@@ -132,10 +132,10 @@
             public const string Log = "https://purl.imsglobal.org/spec/lti-dl/claim/log";
 
             /// <summary>
-            /// User ID as defined in LTI 1.1.
+            /// Optional LTI 1.1 migration mapping.
             /// </summary>
-            public const string Lti11LegacyUserId = "https://purl.imsglobal.org/spec/lti/claim/lti11_legacy_user_id";
-            
+            public const string LtiMigration = "https://purl.imsglobal.org/spec/lti/claim/lti1p1";
+
             /// <summary>
             /// Optional plain text message.
             /// </summary>

--- a/src/LtiAdvantage/Constants.cs
+++ b/src/LtiAdvantage/Constants.cs
@@ -132,6 +132,11 @@
             public const string Log = "https://purl.imsglobal.org/spec/lti-dl/claim/log";
 
             /// <summary>
+            /// Obsolete: LTI 1.1 migration mapping.
+            /// </summary>
+            public const string Lti11LegacyUserId = "https://purl.imsglobal.org/spec/lti/claim/lti11_legacy_user_id";
+
+            /// <summary>
             /// Optional LTI 1.1 migration mapping.
             /// </summary>
             public const string LtiMigration = "https://purl.imsglobal.org/spec/lti/claim/lti1p1";

--- a/src/LtiAdvantage/Lti/LtiMigrationClaimValueType.cs
+++ b/src/LtiAdvantage/Lti/LtiMigrationClaimValueType.cs
@@ -1,0 +1,49 @@
+﻿using Newtonsoft.Json;
+
+namespace LtiAdvantage.Lti
+{
+    /// <summary>
+    /// A mapping of ids that have shifted with the transition to LTI 1.3, 
+    /// allowing the tool to associate existing records to new LTI 1.3 identifiers.
+    /// </summary>
+    public class LtiMigrationClaimValueType
+    {
+
+        /// <summary>
+        /// LTI 1.1 OAuth consumer key.
+        /// </summary>
+        [JsonProperty("oauth_consumer_key", Required = Required.Always)]
+        public string OAuthConsumerKey { get; set; }
+
+        /// <summary>
+        /// A signature for validating the <see cref="OAuthConsumerKey"/> to allow
+        /// the tool to automate a migration.
+        /// </summary>
+        [JsonProperty("oauth_consumer_key_sign")]
+        public string OAuthConsumerKeySignature { get; set; }
+
+        /// <summary>
+        /// LTI 1.1 user ID value associated with the end-user.
+        /// </summary>
+        [JsonProperty("user_id")]
+        public string UserId { get; set; }
+
+        /// <summary>
+        /// LTI 1.1 context ID.
+        /// </summary>
+        [JsonProperty("context_id")]
+        public string ContextId { get; set; }
+
+        /// <summary>
+        /// LTI 1.1 tool consumer instance GUID.
+        /// </summary>
+        [JsonProperty("tool_consumer_instance_guid")]
+        public string ToolConsumerInstanceGuid { get; set; }
+
+        /// <summary>
+        /// LTI 1.1 resource link ID.
+        /// </summary>
+        [JsonProperty("resource_link_id")]
+        public string ResourceLinkId { get; set; }
+    }
+}

--- a/src/LtiAdvantage/Lti/LtiRequest.cs
+++ b/src/LtiAdvantage/Lti/LtiRequest.cs
@@ -57,7 +57,7 @@ namespace LtiAdvantage.Lti
         public string[] Audiences
         {
             get { return this.GetClaimValue<string[]>(JwtRegisteredClaimNames.Aud); }
-            set { this.SetClaimValue(JwtRegisteredClaimNames.Aud, value);}
+            set { this.SetClaimValue(JwtRegisteredClaimNames.Aud, value); }
         }
 
         /// <summary>
@@ -68,15 +68,6 @@ namespace LtiAdvantage.Lti
         {
             get { return this.GetClaimValue(Constants.LtiClaims.DeploymentId); }
             set { this.SetClaimValue(Constants.LtiClaims.DeploymentId, value); }
-        }
-
-        /// <summary>
-        /// User ID as defined in LTI 1.1.
-        /// </summary>
-        public string Lti11LegacyUserId
-        {
-            get { return this.GetClaimValue(Constants.LtiClaims.Lti11LegacyUserId); }
-            set { this.SetClaimValue(Constants.LtiClaims.Lti11LegacyUserId, value); }
         }
 
         /// <summary>
@@ -113,12 +104,12 @@ namespace LtiAdvantage.Lti
         }
 
         /// <summary>
-        /// The tool's url.
+        /// The tool's URL.
         /// </summary>
         public string TargetLinkUri
         {
             get { return this.GetClaimValue(Constants.LtiClaims.TargetLinkUri); }
-            set { this.SetClaimValue(Constants.LtiClaims.TargetLinkUri, value);}
+            set { this.SetClaimValue(Constants.LtiClaims.TargetLinkUri, value); }
         }
 
         /// <summary>
@@ -179,7 +170,16 @@ namespace LtiAdvantage.Lti
         public LisClaimValueType Lis
         {
             get { return this.GetClaimValue<LisClaimValueType>(Constants.LtiClaims.Lis); }
-            set { this.SetClaimValue(Constants.LtiClaims.Lis, value);}
+            set { this.SetClaimValue(Constants.LtiClaims.Lis, value); }
+        }
+
+        /// <summary>
+        /// A mapping of ids that have shifted with the transition to LTI 1.3.
+        /// </summary>
+        public LtiMigrationClaimValueType Lti11
+        {
+            get { return this.GetClaimValue<LtiMigrationClaimValueType>(Constants.LtiClaims.LtiMigration); }
+            set { this.SetClaimValue(Constants.LtiClaims.LtiMigration, value); }
         }
 
         /// <summary>

--- a/src/LtiAdvantage/Lti/LtiRequest.cs
+++ b/src/LtiAdvantage/Lti/LtiRequest.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using LtiAdvantage.Utilities;
@@ -68,6 +69,16 @@ namespace LtiAdvantage.Lti
         {
             get { return this.GetClaimValue(Constants.LtiClaims.DeploymentId); }
             set { this.SetClaimValue(Constants.LtiClaims.DeploymentId, value); }
+        }
+
+        /// <summary>
+        /// Obsolete: User ID as defined in LTI 1.1.
+        /// </summary>
+        [Obsolete("This claim has been removed from the current LTI spec. Use Lti11 migration claim instead.", false)]
+        public string Lti11LegacyUserId
+        {
+            get { return this.GetClaimValue(Constants.LtiClaims.Lti11LegacyUserId); }
+            set { this.SetClaimValue(Constants.LtiClaims.Lti11LegacyUserId, value); }
         }
 
         /// <summary>

--- a/src/LtiAdvantage/LtiAdvantage.csproj
+++ b/src/LtiAdvantage/LtiAdvantage.csproj
@@ -1,50 +1,50 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<Description>.NET Core library with IMS LTIAdvantage support for Tool Consumer and Tool Provider applications.</Description>
-		<AssemblyTitle>LtiAdvantage</AssemblyTitle>
-		<TargetFramework>netstandard2.0</TargetFramework>
-		<AssemblyName>LtiAdvantage</AssemblyName>
-		<PackageId>LtiAdvantage</PackageId>
-		<PackageTags>IMS;LTI;LTIAdvantage;.NET Core</PackageTags>
-		<PackageProjectUrl>https://github.com/LtiLibrary/LtiAdvantage</PackageProjectUrl>
-		<PackageLicenseUrl>https://github.com/LtiLibrary/LtiAdvantage/blob/master/LICENSE</PackageLicenseUrl>
-		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/LtiLibrary/LtiAdvantage</RepositoryUrl>
-		<MinVerTagPrefix>v</MinVerTagPrefix>
-	</PropertyGroup>
+  <PropertyGroup>
+    <Description>.NET Core library with IMS LTIAdvantage support for Tool Consumer and Tool Provider applications.</Description>
+    <AssemblyTitle>LtiAdvantage</AssemblyTitle>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>LtiAdvantage</AssemblyName>
+    <PackageId>LtiAdvantage</PackageId>
+    <PackageTags>IMS;LTI;LTIAdvantage;.NET Core</PackageTags>
+    <PackageProjectUrl>https://github.com/LtiLibrary/LtiAdvantage</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/LtiLibrary/LtiAdvantage/blob/master/LICENSE</PackageLicenseUrl>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/LtiLibrary/LtiAdvantage</RepositoryUrl>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+  </PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<DocumentationFile>$(ProjectDir)LtiAdvantage.xml</DocumentationFile>
-	</PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DocumentationFile>$(ProjectDir)LtiAdvantage.xml</DocumentationFile>
+  </PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-		<DocumentationFile>$(ProjectDir)LtiAdvantage.xml</DocumentationFile>
-	</PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>$(ProjectDir)LtiAdvantage.xml</DocumentationFile>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="BouncyCastle.NetCore" Version="1.8.3" />
-		<PackageReference Include="MinVer" Version="2.3.0">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BouncyCastle.NetCore" Version="1.8.3" />
+    <PackageReference Include="MinVer" Version="2.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-		<PackageReference Include="Microsoft.AspNetCore" Version="2.1.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.1.30" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="2.2.0">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.3.0" />
-	</ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.1.30" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="2.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.3.0" />
+  </ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.19" />
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.5.0" />
-	</ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.19" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.5.0" />
+  </ItemGroup>
 
 </Project>

--- a/src/LtiAdvantage/LtiAdvantage.csproj
+++ b/src/LtiAdvantage/LtiAdvantage.csproj
@@ -1,42 +1,50 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <Description>.NET Core library with IMS LTIAdvantage support for Tool Consumer and Tool Provider applications.</Description>
-    <AssemblyTitle>LtiAdvantage</AssemblyTitle>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>LtiAdvantage</AssemblyName>
-    <PackageId>LtiAdvantage</PackageId>
-    <PackageTags>IMS;LTI;LTIAdvantage;.NET Core</PackageTags>
-    <PackageProjectUrl>https://github.com/LtiLibrary/LtiAdvantage</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/LtiLibrary/LtiAdvantage/blob/master/LICENSE</PackageLicenseUrl>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/LtiLibrary/LtiAdvantage</RepositoryUrl>
-    <MinVerTagPrefix>v</MinVerTagPrefix>
-  </PropertyGroup>
+	<PropertyGroup>
+		<Description>.NET Core library with IMS LTIAdvantage support for Tool Consumer and Tool Provider applications.</Description>
+		<AssemblyTitle>LtiAdvantage</AssemblyTitle>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<AssemblyName>LtiAdvantage</AssemblyName>
+		<PackageId>LtiAdvantage</PackageId>
+		<PackageTags>IMS;LTI;LTIAdvantage;.NET Core</PackageTags>
+		<PackageProjectUrl>https://github.com/LtiLibrary/LtiAdvantage</PackageProjectUrl>
+		<PackageLicenseUrl>https://github.com/LtiLibrary/LtiAdvantage/blob/master/LICENSE</PackageLicenseUrl>
+		<RepositoryType>git</RepositoryType>
+		<RepositoryUrl>https://github.com/LtiLibrary/LtiAdvantage</RepositoryUrl>
+		<MinVerTagPrefix>v</MinVerTagPrefix>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>$(ProjectDir)LtiAdvantage.xml</DocumentationFile>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<DocumentationFile>$(ProjectDir)LtiAdvantage.xml</DocumentationFile>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>$(ProjectDir)LtiAdvantage.xml</DocumentationFile>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<DocumentationFile>$(ProjectDir)LtiAdvantage.xml</DocumentationFile>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="MinVer" Version="2.3.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="BouncyCastle.NetCore" Version="1.8.3" />
+		<PackageReference Include="MinVer" Version="2.3.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+	</ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.3.0" />
-  </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+		<PackageReference Include="Microsoft.AspNetCore" Version="2.1.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.1.30" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="2.2.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.3.0" />
+	</ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.19" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.5.0" />
-  </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.19" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.5.0" />
+	</ItemGroup>
 
 </Project>

--- a/src/LtiAdvantage/LtiAdvantage.csproj
+++ b/src/LtiAdvantage/LtiAdvantage.csproj
@@ -23,22 +23,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.NetCore" Version="1.8.3" />
     <PackageReference Include="MinVer" Version="2.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.1.30" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="2.2.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.3.0" />
   </ItemGroup>
 

--- a/src/LtiAdvantage/LtiAdvantage.xml
+++ b/src/LtiAdvantage/LtiAdvantage.xml
@@ -388,9 +388,9 @@
             Optional plain text message.
             </summary>
         </member>
-        <member name="F:LtiAdvantage.Constants.LtiClaims.Lti11LegacyUserId">
+        <member name="F:LtiAdvantage.Constants.LtiClaims.LtiMigration">
             <summary>
-            User ID as defined in LTI 1.1.
+            Optional LTI 1.1 migration mapping.
             </summary>
         </member>
         <member name="F:LtiAdvantage.Constants.LtiClaims.Message">
@@ -2357,6 +2357,43 @@
             <summary>
             </summary>
         </member>
+        <member name="T:LtiAdvantage.Lti.LtiMigrationClaimValueType">
+            <summary>
+            A mapping of ids that have shifted with the transition to LTI 1.3, 
+            allowing the tool to associate existing records to new LTI 1.3 identifiers.
+            </summary>
+        </member>
+        <member name="P:LtiAdvantage.Lti.LtiMigrationClaimValueType.OAuthConsumerKey">
+            <summary>
+            LTI 1.1 OAuth consumer key.
+            </summary>
+        </member>
+        <member name="P:LtiAdvantage.Lti.LtiMigrationClaimValueType.OAuthConsumerKeySignature">
+            <summary>
+            A signature for validating the <see cref="P:LtiAdvantage.Lti.LtiMigrationClaimValueType.OAuthConsumerKey"/> to allow
+            the tool to automate a migration.
+            </summary>
+        </member>
+        <member name="P:LtiAdvantage.Lti.LtiMigrationClaimValueType.UserId">
+            <summary>
+            LTI 1.1 user ID value associated with the end-user.
+            </summary>
+        </member>
+        <member name="P:LtiAdvantage.Lti.LtiMigrationClaimValueType.ContextId">
+            <summary>
+            LTI 1.1 context ID.
+            </summary>
+        </member>
+        <member name="P:LtiAdvantage.Lti.LtiMigrationClaimValueType.ToolConsumerInstanceGuid">
+            <summary>
+            LTI 1.1 tool consumer instance GUID.
+            </summary>
+        </member>
+        <member name="P:LtiAdvantage.Lti.LtiMigrationClaimValueType.ResourceLinkId">
+            <summary>
+            LTI 1.1 resource link ID.
+            </summary>
+        </member>
         <member name="T:LtiAdvantage.Lti.LtiRequest">
             <inheritdoc />
             <summary>
@@ -2398,11 +2435,6 @@
             contains a string that identifies the platform-tool integration governing the message.
             </summary>
         </member>
-        <member name="P:LtiAdvantage.Lti.LtiRequest.Lti11LegacyUserId">
-            <summary>
-            User ID as defined in LTI 1.1.
-            </summary>
-        </member>
         <member name="P:LtiAdvantage.Lti.LtiRequest.MessageType">
             <summary>
             The type of LTI message.
@@ -2426,7 +2458,7 @@
         </member>
         <member name="P:LtiAdvantage.Lti.LtiRequest.TargetLinkUri">
             <summary>
-            The tool's url.
+            The tool's URL.
             </summary>
         </member>
         <member name="P:LtiAdvantage.Lti.LtiRequest.UserId">
@@ -2460,6 +2492,11 @@
             <summary>
             Properties about available Learning Information Services (LIS),
             usually originating from the Student Information System.
+            </summary>
+        </member>
+        <member name="P:LtiAdvantage.Lti.LtiRequest.Lti11">
+            <summary>
+            A mapping of ids that have shifted with the transition to LTI 1.3.
             </summary>
         </member>
         <member name="P:LtiAdvantage.Lti.LtiRequest.Platform">

--- a/test/LtiAdvantage.UnitTests/Lti/LtiResourceLinkRequestShould.cs
+++ b/test/LtiAdvantage.UnitTests/Lti/LtiResourceLinkRequestShould.cs
@@ -23,7 +23,6 @@ namespace LtiAdvantage.UnitTests.Lti
                     Id = "12345"
                 },
                 UserId = "12345",
-                Lti11LegacyUserId = "12345",
                 Roles = new[]{Role.ContextInstructor, Role.InstitutionInstructor}
             };
 
@@ -46,9 +45,6 @@ namespace LtiAdvantage.UnitTests.Lti
 
             Assert.True(request.TryGetValue("sub", out var sub));
             Assert.Equal("12345", sub);
-
-            Assert.True(request.TryGetValue("https://purl.imsglobal.org/spec/lti/claim/lti11_legacy_user_id", out var legacyUserId));
-            Assert.Equal("12345", legacyUserId);
 
             Assert.True(request.TryGetValue("https://purl.imsglobal.org/spec/lti/claim/roles", out var rolesJson));
             var roles = ((JArray) rolesJson).ToObject<string[]>();

--- a/test/LtiAdvantage.UnitTests/ReferenceJson/LtiResourceLinkRequest.json
+++ b/test/LtiAdvantage.UnitTests/ReferenceJson/LtiResourceLinkRequest.json
@@ -14,7 +14,6 @@
   "email": "jane@platform.example.edu",
   "locale": "en-US",
   "https://purl.imsglobal.org/spec/lti/claim/deployment_id": "07940580-b309-415e-a37c-914d387c1150",
-  "https://purl.imsglobal.org/spec/lti/claim/lti11_legacy_user_id": "a6d5c443-1f51-4783-ba1a-7686ffe3b54a",
   "https://purl.imsglobal.org/spec/lti/claim/message_type": "LtiResourceLinkRequest",
   "https://purl.imsglobal.org/spec/lti/claim/version": "1.3.0",
   "https://purl.imsglobal.org/spec/lti/claim/roles": [
@@ -39,7 +38,7 @@
     "title": "Introduction Assignment"
   },
   "https://purl.imsglobal.org/spec/lti/claim/tool_platform": {
-    "guid": "https://platform.example.edu",
+    "guid": "ex/48bbb541-ce55-456e-8b7d-ebc59a38d435",
     "contact_email": "support@platform.example.edu",
     "description": "An Example Tool Platform",
     "name": "Example Tool Platform",
@@ -47,6 +46,7 @@
     "product_family_code": "ExamplePlatformVendor-Product",
     "version": "1.0"
   },
+  "https://purl.imsglobal.org/spec/lti/claim/target_link_uri": "https://tool.example.com/lti/48320/ruix8782rs",
   "https://purl.imsglobal.org/spec/lti/claim/launch_presentation": {
     "document_target": "iframe",
     "height": 320,


### PR DESCRIPTION
This removes the lti11_legacy_user_id claim, per the [changelog](https://lti-ri.imsglobal.org/release_notes). It is no longer required. Adds the LTI 1.1 migration claim from the [migration docs](https://www.imsglobal.org/spec/lti/v1p3/migr).