### PR TITLE
Allow line item result score to be null.

### DIFF
--- a/src/LtiAdvantage/AssignmentGradeServices/Result.cs
+++ b/src/LtiAdvantage/AssignmentGradeServices/Result.cs
@@ -34,7 +34,7 @@ namespace LtiAdvantage.AssignmentGradeServices
         /// The line item result.
         /// </summary>
         [JsonProperty("resultScore")]
-        public double ResultScore { get; set; }
+        public double? ResultScore { get; set; }
 
         /// <summary>
         /// The line item.


### PR DESCRIPTION
This is specifically to support platforms returning null in the resultScore field of the line item result.