### PR TITLE
Drop ASP.NET Core 2.1 support for tests

### DIFF
--- a/test/LtiAdvantage.IntegrationTests/LtiAdvantage.IntegrationTests.csproj
+++ b/test/LtiAdvantage.IntegrationTests/LtiAdvantage.IntegrationTests.csproj
@@ -1,15 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
-  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.9" />

--- a/test/LtiAdvantage.UnitTests/LtiAdvantage.UnitTests.csproj
+++ b/test/LtiAdvantage.UnitTests/LtiAdvantage.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Eliminates build warnings now that ASP.NET Core 2.1 is no longer supported for quite a while (August 21, 2021)