### PR TITLE
Support the TestUser role

### DIFF
--- a/src/LtiAdvantage/Lti/Role.cs
+++ b/src/LtiAdvantage/Lti/Role.cs
@@ -189,5 +189,14 @@ namespace LtiAdvantage.Lti
         SystemUser,
 
         #endregion
+
+        #region LTI System Roles
+
+        /// <summary>
+        /// </summary>
+        [Uri("http://purl.imsglobal.org/vocab/lti/system/person#TestUser")]
+        LtiSystemTestUser,
+
+        #endregion
     }
 }


### PR DESCRIPTION
This adds an entry for the `TestUser` role in `Role` enumeration. I categorized this new role separately from the other system roles as the spec labels it under "LTI vocabulary" (separate from the "LIS vocabulary"), but I'm happy to rename/reorganize if there are better suggestions.

Spec: https://www.imsglobal.org/node/162741#lti-vocabulary-for-system-roles