### PR TITLE
Fix typo in GradingProgress identifier. Fixes #98

### DIFF
--- a/src/LtiAdvantage/AssignmentGradeServices/GradingProgress.cs
+++ b/src/LtiAdvantage/AssignmentGradeServices/GradingProgress.cs
@@ -6,7 +6,7 @@ namespace LtiAdvantage.AssignmentGradeServices
     /// The grading progress.
     /// </summary>
     [JsonConverter(typeof(JsonStringEnumConverter))]
-    public enum GradingProgess
+    public enum GradingProgress
     {
         /// <summary>
         /// Unknown grading progress.

--- a/src/LtiAdvantage/AssignmentGradeServices/Score.cs
+++ b/src/LtiAdvantage/AssignmentGradeServices/Score.cs
@@ -25,7 +25,7 @@ namespace LtiAdvantage.AssignmentGradeServices
         /// The status of the grading process.
         /// </summary>
         [JsonPropertyName("gradingProgress")]
-        public GradingProgess GradingProgress { get; set; }
+        public GradingProgress GradingProgress { get; set; }
 
         /// <summary>
         /// The score.

--- a/test/LtiAdvantage.UnitTests/AssignmentGradeServices/ScoreShould.cs
+++ b/test/LtiAdvantage.UnitTests/AssignmentGradeServices/ScoreShould.cs
@@ -22,7 +22,7 @@ namespace LtiAdvantage.UnitTests.AssignmentGradeServices
             Assert.Equal(100, score.ScoreMaximum);
             Assert.Equal("This is exceptional work.", score.Comment);
             Assert.Equal(ActivityProgress.Completed, score.ActivityProgress);
-            Assert.Equal(GradingProgess.FullyGraded, score.GradingProgress);
+            Assert.Equal(GradingProgress.FullyGraded, score.GradingProgress);
             Assert.Equal("5323497", score.UserId);
         }
 


### PR DESCRIPTION
Corrected multiple instances of "GradingProgess" to "GradingProgress" in the codebase. This includes updates to enums, property names, and associated unit tests.