### PR TITLE
Fix quoted claim value deserialization.

### DIFF
--- a/src/LtiAdvantage/Utilities/JwtExtensions.cs
+++ b/src/LtiAdvantage/Utilities/JwtExtensions.cs
@@ -1,9 +1,11 @@
 ﻿using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Security.Claims;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
+[assembly: InternalsVisibleTo("LtiAdvantage.UnitTests")]
 namespace LtiAdvantage.Utilities
 {
     /// <summary>
@@ -41,9 +43,7 @@ namespace LtiAdvantage.Utilities
 
             if (payload.TryGetValue(type, out var value))
             {
-                return typeof(T) == typeof(string)
-                    ? JsonSerializer.Deserialize<T>($"\"{value}\"")
-                    : JsonSerializer.Deserialize<T>(value.ToString());
+                return JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(value));
             }
 
             return default(T);
@@ -58,12 +58,7 @@ namespace LtiAdvantage.Utilities
             if (0 == values.Length)
                 return default(T);
 
-            var elementType = typeof(T).GetElementType();
-            if (elementType != null && elementType.IsClass && !elementType.IsEquivalentTo(typeof(string)))
-            {
-                return JsonSerializer.Deserialize<T>("[" + string.Join(",", values) + "]");
-            }
-            return JsonSerializer.Deserialize<T>("[\"" + string.Join("\",\"", values) + "\"]");
+            return JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(values));
         }
 
         public static void SetClaimValue<T>(this JwtPayload payload, string type, T value)

--- a/test/LtiAdvantage.UnitTests/Utilities/JwtExtensionsShould.cs
+++ b/test/LtiAdvantage.UnitTests/Utilities/JwtExtensionsShould.cs
@@ -1,0 +1,228 @@
+using System.Linq;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using LtiAdvantage.Utilities;
+using System.Text.Json;
+using Xunit;
+
+namespace LtiAdvantage.UnitTests.Utilities
+{
+    public class JwtExtensionsShould
+    {
+        /// <summary>
+        /// Verifies that GetClaimValue can retrieve a string claim value.
+        /// </summary>
+        [Fact]
+        public void GetClaimValue_ReturnStringValue()
+        {
+            var payload = new JwtPayload();
+            var claimType = "name";
+            var claimValue = "John Doe";
+            payload.AddClaim(new Claim(claimType, claimValue));
+
+            var result = payload.GetClaimValue(claimType);
+
+            Assert.Equal(claimValue, result);
+        }
+
+        /// <summary>
+        /// Verifies that GetClaimValue can handle double quotes in string claim values.
+        /// </summary>
+        [Fact]
+        public void GetClaimValue_HandleDoubleQuotesInString()
+        {
+            var payload = new JwtPayload();
+            var claimType = "quote";
+            var claimValue = "He said, \"Hello, World!\"";
+            payload.AddClaim(new Claim(claimType, claimValue));
+
+            var result = payload.GetClaimValue(claimType);
+
+            Assert.Equal(claimValue, result);
+        }
+
+        /// <summary>
+        /// Verifies that GetClaimValue can retrieve an integer claim value.
+        /// </summary>
+        [Fact]
+        public void GetClaimValue_ReturnIntegerValue()
+        {
+            var payload = new JwtPayload();
+            var claimType = "age";
+            var claimValue = 30;
+            payload.AddClaim(new Claim(claimType, claimValue.ToString(), ClaimValueTypes.Integer));
+
+            var result = payload.GetClaimValue<int>(claimType);
+
+            Assert.Equal(claimValue, result);
+        }
+
+        /// <summary>
+        /// Verifies that GetClaimValue returns default when claim is not found.
+        /// </summary>
+        [Fact]
+        public void GetClaimValue_ReturnDefaultWhenClaimNotFound()
+        {
+            var payload = new JwtPayload();
+            var claimType = "nonexistent";
+
+            var result = payload.GetClaimValue<string>(claimType);
+
+            Assert.Null(result);
+        }
+
+        /// <summary>
+        /// Verifies that GetClaimValues can retrieve an array of string claim values.
+        /// </summary>
+        [Fact]
+        public void GetClaimValues_ReturnStringArray()
+        {
+            var payload = new JwtPayload();
+            var claimType = "roles";
+            var claimValues = new[] { "admin", "user", "editor" };
+            foreach (var value in claimValues)
+            {
+                payload.AddClaim(new Claim(claimType, value));
+            }
+
+            var result = payload.GetClaimValue<string[]>(claimType);
+
+            Assert.Equal(claimValues, result);
+        }
+
+        /// <summary>
+        /// Verifies that GetClaimValues can handle arrays with special characters.
+        /// </summary>
+        [Fact]
+        public void GetClaimValues_HandleSpecialCharactersInArray()
+        {
+            var payload = new JwtPayload();
+            var claimType = "quotes";
+            var claimValues = new[] { "Value with \"quotes\"", "Another \"value\"" };
+            foreach (var value in claimValues)
+            {
+                payload.AddClaim(new Claim(claimType, value));
+            }
+
+            var result = payload.GetClaimValue<string[]>(claimType);
+
+            Assert.Equal(claimValues, result);
+        }
+
+        /// <summary>
+        /// Verifies that SetClaimValue can add a string claim to the payload.
+        /// </summary>
+        [Fact]
+        public void SetClaimValue_AddStringClaim()
+        {
+            var payload = new JwtPayload();
+            var claimType = "nickname";
+            var claimValue = "Johnny";
+
+            payload.SetClaimValue(claimType, claimValue);
+
+            var result = payload.Claims.FirstOrDefault(c => c.Type == claimType)?.Value;
+            Assert.Equal(claimValue, result);
+        }
+
+        /// <summary>
+        /// Verifies that SetClaimValue can add an integer claim to the payload.
+        /// </summary>
+        [Fact]
+        public void SetClaimValue_AddIntegerClaim()
+        {
+            var payload = new JwtPayload();
+            var claimType = "score";
+            var claimValue = 100;
+
+            payload.SetClaimValue(claimType, claimValue);
+
+            var result = payload.GetClaimValue<int>(claimType);
+            Assert.Equal(claimValue, result);
+        }
+
+        /// <summary>
+        /// Verifies that SetClaimValue can add an array of strings as a claim.
+        /// </summary>
+        [Fact]
+        public void SetClaimValue_AddStringArrayClaim()
+        {
+            var payload = new JwtPayload();
+            var claimType = "permissions";
+            var claimValue = new[] { "read", "write", "execute" };
+
+            payload.SetClaimValue(claimType, claimValue);
+
+            var result = payload.GetClaimValue<string[]>(claimType);
+            Assert.Equal(claimValue, result);
+        }
+
+        /// <summary>
+        /// Verifies that SetClaimValue overwrites existing claims of the same type.
+        /// </summary>
+        [Fact]
+        public void SetClaimValue_OverwriteExistingClaim()
+        {
+            var payload = new JwtPayload();
+            var claimType = "email";
+            var initialValue = "old.email@example.com";
+            var newValue = "new.email@example.com";
+            payload.AddClaim(new Claim(claimType, initialValue));
+
+            payload.SetClaimValue(claimType, newValue);
+
+            var result = payload.GetClaimValue(claimType);
+            Assert.Equal(newValue, result);
+        }
+
+        /// <summary>
+        /// Verifies that GetClaimValue can handle JSON-formatted claim values.
+        /// </summary>
+        [Fact]
+        public void GetClaimValue_HandleJsonFormattedValue()
+        {
+            var payload = new JwtPayload();
+            var claimType = "metadata";
+            var claimObject = new { Key = "Value", Number = 42 };
+            var claimValue = JsonSerializer.Serialize(claimObject);
+            payload.AddClaim(new Claim(claimType, claimValue, JsonClaimValueTypes.Json));
+
+            var result = payload.GetClaimValue<JsonElement>(claimType);
+
+            Assert.Equal("Value", result.GetProperty("Key").GetString());
+            Assert.Equal(42, result.GetProperty("Number").GetInt32());
+        }
+
+        /// <summary>
+        /// Verifies that GetClaimValue returns default for empty payload.
+        /// </summary>
+        [Fact]
+        public void GetClaimValue_ReturnDefaultForEmptyPayload()
+        {
+            var payload = new JwtPayload();
+            var claimType = "anyClaim";
+
+            var result = payload.GetClaimValue<string>(claimType);
+
+            Assert.Null(result);
+        }
+
+        /// <summary>
+        /// Verifies that SetClaimValue removes existing claims before adding new ones.
+        /// </summary>
+        [Fact]
+        public void SetClaimValue_RemoveExistingClaimsBeforeAdding()
+        {
+            var payload = new JwtPayload();
+            var claimType = "role";
+            payload.AddClaim(new Claim(claimType, "user"));
+            payload.AddClaim(new Claim(claimType, "admin"));
+
+            payload.SetClaimValue(claimType, "superuser");
+
+            var claims = payload.Claims.Where(c => c.Type == claimType).ToList();
+            Assert.Single(claims);
+            Assert.Equal("superuser", claims.First().Value);
+        }
+    }
+}


### PR DESCRIPTION
_Resolves #134_

This pull request resolves the issue where `JwtExtensions.GetClaimValue<T>` throws a deserialization exception when claim values contain double quotes (`"`).

**Changes Made:**

- Updated `GetClaimValue<T>` method:

  ```csharp
  if (payload.TryGetValue(type, out var value))
  {
      return JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(value));
  }
  ```

- Updated `GetClaimValues<T>` method:

  ```csharp
  return JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(values));
  ```

These changes ensure that special characters in claim values are properly escaped during serialization.

**Testing:**

- Added unit tests to verify that claim values containing double quotes are correctly deserialized without exceptions.